### PR TITLE
11 replace cookies with localstorage

### DIFF
--- a/src/Bookmark.js
+++ b/src/Bookmark.js
@@ -1,6 +1,6 @@
 import { faStar as fasStar } from '@fortawesome/free-solid-svg-icons';
 import { faStar } from '@fortawesome/free-regular-svg-icons';
-import { COOKIE_NAME, get_cookie_list, cookies } from "./Utils.js"
+import { COOKIE_NAME, get_cookie_list, cookies, cookie_parameters } from "./Utils.js"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useEffect, useState } from 'react';
 
@@ -12,7 +12,7 @@ export default function Bookmark({index}) {
     let current_cookie_list = get_cookie_list();
     if(starType === faStar){ // add cookie
       current_cookie_list.push(index);
-      cookies.set(COOKIE_NAME, current_cookie_list.join(","));
+      cookies.set(COOKIE_NAME, current_cookie_list.join(","), cookie_parameters);
       setStarType(fasStar);
     }
     else{ // remove cookie
@@ -20,7 +20,7 @@ export default function Bookmark({index}) {
       if (cookie_idx_rm > -1){
         current_cookie_list.splice(cookie_idx_rm, 1);
       }
-      cookies.set(COOKIE_NAME, current_cookie_list.join(","));
+      cookies.set(COOKIE_NAME, current_cookie_list.join(","), cookie_parameters);
       setStarType(faStar);
     }
   } 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -3,6 +3,9 @@ export let colors = ["purple","fuchsia","green","lime","olive","yellow","navy","
 
 export const COOKIE_NAME = "BOOKMARKS";
 
+let today = new Date();
+today.setDate(today.getDate() + 7);
+export const cookie_parameters = {expires: today, sameSite:"lax"}
 export const cookies = new Cookies();
 
 export function get_cookie_list(){

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -4,7 +4,7 @@ export let colors = ["purple","fuchsia","green","lime","olive","yellow","navy","
 export const COOKIE_NAME = "BOOKMARKS";
 
 let today = new Date();
-today.setDate(today.getDate() + 7);
+today.setDate(today.getDate() + 30);
 export const cookie_parameters = {expires: today, sameSite:"lax"}
 export const cookies = new Cookies();
 


### PR DESCRIPTION
this specific PR addresses the problem of cookies dying when the user closes the entire browser, but leaves open the option of switching to localstorage entirely.